### PR TITLE
Add compatibility flag to bundler in macOS setup script

### DIFF
--- a/setup/macOS-setup.sh
+++ b/setup/macOS-setup.sh
@@ -106,6 +106,7 @@ else
 fi
 
 printf '[*] Installing Gems... \n'
+output_line "bundle config build.nio4r --with-cflags='-Wno-incompatible-pointer-types'"
 output_line "bundle install" && print_success "${CLEAR_LINE}[+] Gems installed\n"
 
 printf '[*] Checking for application configurations... \n'


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
< describe the purpose of this pull request and note the issue it addresses >

- Add compatibility flag to bundler in macOS setup script (commit 1)
    -  This adds a compatibility flag to resolve errors like the following
        - `compiling selector.c
selector.c:301:26: error: incompatible function pointer types passing 'VALUE (*)(VALUE *)' (aka 'unsigned long (*)(unsigned long *)') to parameter of type 'VALUE (*)(VALUE)' (aka 'unsigned long (*)(unsigned long)')
[-Wincompatible-function-pointer-types]`
       - See full error log here:  [error_one.txt](https://github.com/user-attachments/files/19522981/two.txt)
        - Source: https://stackoverflow.com/questions/78313570/unable-to-bundle-install-nio4r-on-a-new-mac-m3 
## Screenshots
Before:
< add a screenshot of the UI before your change >

After:
< add a screenshot of the UI after your change >
## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
